### PR TITLE
Add starter pack submodule and update build script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "decks/starter-pack"]
+	path = decks/starter-pack
+	url = git@github.com:jbcdnr/slides--starter-pack.git

--- a/sketch-generate.sh
+++ b/sketch-generate.sh
@@ -7,10 +7,13 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# generate data_dir path_to_preprocess_slides.py
 function generate {
     rm -rf "$1/*.svg"
     sketchtool export artboards --formats=svg --output="$1" "$1/slides.sketch"
-    ./preprocess_slides.py --output "$1/slides.json" --media-out-dir "$1/dist" "$1"
+    $2 --output "$1/slides.json" --media-out-dir "$1/dist" "$1"
 }
 
 export -f generate
@@ -18,4 +21,4 @@ export -f generate
 directory="$1"
 svg_file="${directory}/slides.sketch"
 echo "Watching update of file ${svg_file}..."
-fswatch -o "$svg_file" | xargs -n1 -I{} bash -c "generate '$directory'"
+fswatch -o "$svg_file" | xargs -n1 -I{} bash -c "generate '$directory' '$SCRIPT_DIR/preprocess_slides.py'"


### PR DESCRIPTION
- New directory organisation with each deck of slides in `decks/` as a submodule so the deck of slides can remain private
- And a very [quick start template repository](https://github.com/jbcdnr/slides--starter-pack) with instructions to quickly create a new deck ;)